### PR TITLE
Update links to support page

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -34,8 +34,8 @@
         of utilities including IDF-Editor for creating input files using a simple spreadsheet-like interface, EP-Launch
         for managing input and output files and performing batch simulations, and EP-Compare for graphically comparing
         the results of two or more simulations. Several comprehensive
-        <a href="https://www.buildingenergysoftwaretools.com/?capabilities=Whole-building+Energy+Simulation&keywords=EnergyPlus">
-          graphical interfaces</a> for EnergyPlus are also available. DOE does most of its work with EnergyPlus using the
+        <a href="https://www.ibpsa.us/best-directory-list/">
+          tools</a> for EnergyPlus are also available. DOE does most of its work with EnergyPlus using the
         <a href="https://www.openstudio.net">OpenStudio</a> software development kit and suite of applications.
       </p>
       <p>DOE releases major updates to EnergyPlus twice annually. An updated version {{ latestRelease.version }} with bug fixes was released on {{ latestRelease.date }}.</p>

--- a/src/app/support-training/support-training.component.html
+++ b/src/app/support-training/support-training.component.html
@@ -14,12 +14,9 @@
         StackExchange Q&A websites. Users can ask and answer questions and “vote” questions and answers up or down.
         Users can also subscribe to interesting topics and receive email notifications when new questions about the
         topic are asked—members of the EnergyPlus team subscribe to the tag ‘energyplus’.</p>
-      <h2>Real-Time Email and Phone Support</h2>
-      <p>These <a href="https://buildingenergysoftwaretools.com/?capabilities=Support+Services&keys=EnergyPlus">organizations</a>
-       provide more individual email and/or phone support.</p>
-      <h2>EnergyPlus Training</h2>
-      <p>Several <a href="https://buildingenergysoftwaretools.com/?capabilities=Training+Services&keys=EnergyPlus">organizations</a>
-        provide public and/or private EnergyPlus trainings and workshops.</p>
+      <h2>Real-Time Email, Phone Support, and Training</h2>
+      <p>The <a href="https://www.ibpsa.us/best-directory-list/">BEST Directory</a> lists organizations that can provide 
+        more individual email and/or phone support, as well as public and/or private EnergyPlus training and workshops.</p>
       <h2>EnergyPlus University Course Teaching Material</h2>
       <p>The following curriculum outline and accompanying PowerPoint slides are intended to aid professors in teaching
         a course on EnergyPlus. The course is designed for upper-level undergraduate as well as graduate students. The

--- a/src/app/weather/weather-sources/weather-sources.component.html
+++ b/src/app/weather/weather-sources/weather-sources.component.html
@@ -41,7 +41,7 @@
         <p>TMY data derived for 15 locations in northern Argentina using data from National Meteorological Service (SMN) of Argentina. Developed for use in building energy simulation software in EPW format.</p>
         <p>Bre, Facundo, Víctor D. Fachinotti. 2016. "Generation of typical meteorological years for the Argentine Littoral Region," <em>Energy and Buildings</em>, Vol. 129, Pages 432-444.</p>
         <h2 id="CTZ2">California Climate Zones 2 (CTZ2)</h2>
-        <p>Updated weather data for <a href="http://www.energy.ca.gov/maps/building_climate_zones.html">16 California climate zones</a> (CTZ2) for use to demonstrate compliance with Title 24 with approved building energy simulation programs.
+        <p>Updated weather data for <a href="https://www.energy.ca.gov/programs-and-topics/programs/building-energy-efficiency-standards/climate-zone-tool-maps-and">16 California climate zones</a> (CTZ2) for use to demonstrate compliance with Title 24 with approved building energy simulation programs.
           All 16 CTZ2 weather files are available for download in EnergyPlus weather format. The original source data is available from the <a href="http://www.energy.ca.gov/title24/">California Energy Commission</a>.</p>
         <h2 id="CWEC">Canadian Weather for Energy Calculations (CWEC)</h2>
         <p>The 80 CWEC files contain hourly weather observations representing an artificial one-year period specifically designed for building energy calculations. All 80 locations in the CWEC data set are available for download in EnergyPlus weather format.</p>


### PR DESCRIPTION
The buildingenergysoftwaretools page moved to an IBPSA page, and this updates the 3 spots I found referencing it.  Note that the new web page does not appear to respond to query parameters in the URL, so I couldn't provide direct links to narrowed search results.  I could only provide a link to the main directory.  If someone can figure out a way, that's cool, but I reworded a couple things to keep it making sense at least.